### PR TITLE
Remove App Clip declaration from apple-itunes-app meta tag

### DIFF
--- a/apps/lp/src/pages/index.astro
+++ b/apps/lp/src/pages/index.astro
@@ -73,7 +73,7 @@ const lcpImageSources = lcpFormats.map((format, index) => {
     <meta name="twitter:app:name:googleplay" content="TrainLCD" />
     <meta name="twitter:app:id:googleplay" content="me.tinykitten.trainlcd" />
     <meta property="fb:app_id" content="596269604527027" />
-    <meta name="apple-itunes-app" content="app-id=1486355943, app-clip-bundle-id=me.tinykitten.trainlcd.Clip, app-clip-display=card" />
+    <meta name="apple-itunes-app" content="app-id=1486355943" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
     <link


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Apple iTunes アプリメタタグの設定を更新しました。App Clip関連のパラメータを削除し、アプリID設定のみを保持するように変更されました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/Website/pull/177?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->