### PR TITLE
fix(lp): モバイルでダウンロードバナーを飛び越えるスクロールを修正

### DIFF
--- a/apps/lp/src/components/sections/Download.module.css
+++ b/apps/lp/src/components/sections/Download.module.css
@@ -7,6 +7,8 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  /* 固定ヘッダー分のオフセットを確保してスクロール先のバナーが隠れないようにする */
+  scroll-margin-top: 64px;
   content-visibility: auto;
   contain-intrinsic-size: 720px;
 }

--- a/apps/lp/src/components/sections/Welcome.astro
+++ b/apps/lp/src/components/sections/Welcome.astro
@@ -47,6 +47,42 @@ const { lcpImageSources = [] } = Astro.props;
   </a>
 </section>
 
+<script>
+  // 「使ってみる」ボタンのアンカースクロール処理。
+  // 中間セクションが `content-visibility: auto` のままだと
+  // 推定サイズ（contain-intrinsic-size）で位置計算が行われ、
+  // 実際のレイアウトとズレてダウンロードセクションのバナーを
+  // 飛び越えてスクロールしてしまう。
+  // クリック時に対象より前のセクションを `content-visibility: visible`
+  // に上書きして実サイズでレイアウトさせ、正しい位置にスクロールする。
+  const welcomeButtons = document.querySelectorAll<HTMLAnchorElement>(
+    'a.welcome-button[href^="#"]',
+  );
+
+  welcomeButtons.forEach((button) => {
+    button.addEventListener('click', (event) => {
+      const href = button.getAttribute('href');
+      if (!href || !href.startsWith('#') || href === '#') return;
+      const target = document.querySelector(href);
+      if (!(target instanceof HTMLElement)) return;
+      event.preventDefault();
+
+      const sections = Array.from(
+        document.querySelectorAll<HTMLElement>('section'),
+      );
+      const targetIndex = sections.indexOf(target);
+      if (targetIndex > 0) {
+        for (let i = 0; i < targetIndex; i++) {
+          sections[i].style.contentVisibility = 'visible';
+        }
+      }
+
+      target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      history.replaceState(null, '', href);
+    });
+  });
+</script>
+
 <style is:inline>
   .welcome-container {
     min-height: 100vh;


### PR DESCRIPTION
「使ってみる」ボタン押下時のアンカースクロールでGoogle Play/App Store
バナーを飛び越えてしまう問題を修正。中間セクションの
`content-visibility: auto` による推定サイズで位置計算が行われ、
実レイアウトとずれていたのが原因。

クリック時に対象より前のセクションを `content-visibility: visible`
に上書きして実サイズでレイアウトしてからスクロールするようにし、
ダウンロードセクションには固定ヘッダー分の `scroll-margin-top` を追加。

https://claude.ai/code/session_014NQjc8LsDSVLnDXtkx95k6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ナビゲーションリンクのクリック時にスムーズなスクロール動作を実装しました。

* **改善**
  * 固定ヘッダーによるコンテンツの隠れを防止するため、スクロール位置の調整を改善しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/Website/pull/179?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->