### PR TITLE
chore(lp): Welcomeセクションのボタン文言を「ダウンロード」に変更

### DIFF
--- a/apps/lp/src/components/sections/Welcome.astro
+++ b/apps/lp/src/components/sections/Welcome.astro
@@ -24,7 +24,7 @@ const { lcpImageSources = [] } = Astro.props;
       迷いそうな時、降りれるか不安な時。きっとあなたの役に立つはずです。
     </p>
     <a href="#download" class="welcome-button welcome-button--desktop">
-      使ってみる
+      ダウンロード
     </a>
   </div>
   <div class="welcome-mockup">
@@ -43,12 +43,12 @@ const { lcpImageSources = [] } = Astro.props;
     />
   </div>
   <a href="#download" class="welcome-button welcome-button--mobile">
-    使ってみる
+    ダウンロード
   </a>
 </section>
 
 <script>
-  // 「使ってみる」ボタンのアンカースクロール処理。
+  // 「ダウンロード」ボタンのアンカースクロール処理。
   // 中間セクションが `content-visibility: auto` のままだと
   // 推定サイズ（contain-intrinsic-size）で位置計算が行われ、
   // 実際のレイアウトとズレてダウンロードセクションのバナーを


### PR DESCRIPTION
## Summary
- LPの「使ってみる」ボタン文言を「ダウンロード」に変更（デスクトップ/モバイル両方）
- 関連するJSコメントも追従して更新

## Test plan
- [ ] LPをローカルで起動し、デスクトップ表示でボタンラベルが「ダウンロード」になっていることを確認
- [ ] モバイル幅でも同様に「ダウンロード」と表示されることを確認
- [ ] ボタン押下でダウンロードセクションまでスムーズスクロールする挙動が維持されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI テキスト更新**
  * ウェルカムボタンのテキストを「使ってみる」から「ダウンロード」に変更しました（デスクトップ・モバイル対応）。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/Website/pull/181?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->