### PR TITLE
fix(status): eliminate duplicate getServices call in snapshot API

### DIFF
--- a/apps/status/app/api/status/snapshot/__tests__/route.test.ts
+++ b/apps/status/app/api/status/snapshot/__tests__/route.test.ts
@@ -5,7 +5,7 @@ import { GET } from '../route';
 // Mock the repository functions
 vi.mock('@/server/repo/serviceRepository', () => ({
   getServices: vi.fn().mockResolvedValue([]),
-  getStatusLabel: vi.fn().mockResolvedValue('operational'),
+  computeStatusLabel: vi.fn().mockReturnValue('operational'),
 }));
 
 vi.mock('@/server/repo/incidentRepository', () => ({

--- a/apps/status/app/api/status/snapshot/route.ts
+++ b/apps/status/app/api/status/snapshot/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getServices, getStatusLabel } from '@/server/repo/serviceRepository';
+import { getServices, computeStatusLabel } from '@/server/repo/serviceRepository';
 import { getIncidentHistories } from '@/server/repo/incidentRepository';
 import type { Locale } from '@/server/lib/locale';
 
@@ -41,11 +41,11 @@ function isOriginAllowed(origin: string | null): 'wildcard' | 'specific' | null 
 
 export async function GET(request: NextRequest) {
   const locale = parseLocale(request);
-  const [statusLabel, services, incidents] = await Promise.all([
-    getStatusLabel(locale),
+  const [services, incidents] = await Promise.all([
     getServices(locale),
     getIncidentHistories(locale),
   ]);
+  const statusLabel = computeStatusLabel(services);
 
   const origin = request.headers.get('origin');
   const allowedType = isOriginAllowed(origin);

--- a/apps/status/app/page.tsx
+++ b/apps/status/app/page.tsx
@@ -3,7 +3,7 @@ import Footer from './components/Footer';
 import StatusContent from './components/client/StatusContent';
 import { FeedIcon } from './components/icons/Feed';
 import { XIcon } from './components/icons/X';
-import { getServices, getStatusLabel } from './server/repo/serviceRepository';
+import { getServices, computeStatusLabel } from './server/repo/serviceRepository';
 import { getIncidentHistories } from './server/repo/incidentRepository';
 import { detectLocale } from './server/lib/locale';
 
@@ -13,11 +13,11 @@ export const dynamic = 'force-dynamic';
 export default async function HomePage() {
   const locale = await detectLocale();
   
-  const [statusLabel, services, incidents] = await Promise.all([
-    getStatusLabel(locale),
+  const [services, incidents] = await Promise.all([
     getServices(locale),
     getIncidentHistories(locale),
   ]);
+  const statusLabel = computeStatusLabel(services);
 
   const feedText = locale === 'ja' 
     ? 'フィード登録はこちら: '


### PR DESCRIPTION
## Summary
- `/api/status/snapshot` と トップページで `getStatusLabel(locale)` と `getServices(locale)` を `Promise.all` で並列呼び出ししていたが、`getStatusLabel` 内部でも `getServices` を呼んでおり同じデータを2回取得していた
- Edge Config キャッシュミス時に Neon のコールドスタート（~500ms）が2回走り、レスポンスが約1秒に膨らんでいた
- `getServices` を1回だけ呼び、純粋関数 `computeStatusLabel` でラベルを導出するように変更

## Test plan
- [x] `vitest run` で snapshot route テスト 8件全パス確認済み
- [ ] デプロイ後に `/api/status/snapshot` のレスポンスタイムが改善されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * ステータスラベルの計算処理を最適化し、サービスデータから動的に導出するよう改善しました。
  * データ取得処理を並列化し、フェッチ効率を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->