### PR TITLE
docs(report-incident): SSE/Redis 撤廃後の構成に skill の説明を更新

### DIFF
--- a/.claude/skills/report-incident/SKILL.md
+++ b/.claude/skills/report-incident/SKILL.md
@@ -6,8 +6,9 @@ description: TrainLCD のステータスページ(apps/status)に障害情報を
 # 障害情報の登録 (TrainLCD Status)
 
 `apps/status` のステータスページに障害情報を登録・更新する。データは
-`POST /api/status/events` 経由で PostgreSQL に永続化され、Redis キャッシュ更新と
-SSE 配信まで自動で行われる。投稿には `apps/status/scripts/report-incident.mjs` を使う。
+`POST /api/status/events` 経由で PostgreSQL に永続化され、Vercel Edge Config の
+スナップショット再構築まで自動で行われる（公開ページは `/api/status/snapshot` を
+30秒間隔でポーリングして反映）。投稿には `apps/status/scripts/report-incident.mjs` を使う。
 
 ## ワークフロー
 


### PR DESCRIPTION
## 概要

`report-incident` skill(`.claude/skills/report-incident/SKILL.md`)の冒頭の説明が、SSE/Redis を前提とした古い記述のまま残っていたため、現状の構成に合わせて更新します。

ステータスページは PR #200 で **Edge Config + クライアントポーリング**へ移行し、SSE + Redis pub/sub は撤廃済みです。一方で skill の冒頭にはまだ「Redis キャッシュ更新と SSE 配信まで自動で行われる」という記述が残っていました。

## 変更内容

`SKILL.md` 冒頭の1文を修正:

**変更前**
> データは `POST /api/status/events` 経由で PostgreSQL に永続化され、Redis キャッシュ更新と SSE 配信まで自動で行われる。

**変更後**
> データは `POST /api/status/events` 経由で PostgreSQL に永続化され、Vercel Edge Config のスナップショット再構築まで自動で行われる(公開ページは `/api/status/snapshot` を30秒間隔でポーリングして反映)。

投稿手順そのもの(`npm run report-incident`)は変わっていないため、説明文のみの修正です。

## 影響範囲

- ドキュメント(skill)のみの変更。コード・挙動への影響なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012XPDxSCjAKmJXX7bT3iNqL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 障害情報の登録・更新手順の説明を更新し、反映の流れが最新の動作に合うようになりました。
  * 公開ページへの反映方法について、定期的な更新確認に基づく表示へ変更されたことを明記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->