### PR TITLE
feat(lp): ファーストビュー見出し下段のフォントサイズを1.25倍に

### DIFF
--- a/apps/lp/src/components/sections/Welcome.astro
+++ b/apps/lp/src/components/sections/Welcome.astro
@@ -121,6 +121,7 @@ const { lcpImageSources = [] } = Astro.props;
 
   .welcome-colored {
     color: #1565c0;
+    font-size: 1.5em;
   }
 
   .welcome-heading {

--- a/apps/lp/src/components/sections/Welcome.astro
+++ b/apps/lp/src/components/sections/Welcome.astro
@@ -121,7 +121,7 @@ const { lcpImageSources = [] } = Astro.props;
 
   .welcome-colored {
     color: #1565c0;
-    font-size: 1.5em;
+    font-size: 1.25em;
   }
 
   .welcome-heading {


### PR DESCRIPTION
## 概要

ファーストビューの見出し「電車のあの画面、持ち歩けます。」について、下段「持ち歩けます。」のフォントサイズを上段「電車のあの画面、」の約1.25倍に拡大しました。

## 変更内容

- `apps/lp/src/components/sections/Welcome.astro` の `.welcome-colored`(下段)に `font-size: 1.25em` を追加

`em` は親要素(見出し)のフォントサイズ基準のため、上段に対して自動的に1.25倍になります。ブレークポイントごとの結果は以下の通りです。

| 画面 | 見出し(上段) | 下段(1.25倍) |
| --- | --- | --- |
| モバイル | 1.5rem | 1.875rem |
| デスクトップ (≥768px) | 3rem | 3.75rem |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 強調表示されるテキストのフォントサイズを調整し、青文字の見た目を少し大きくしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->