### PR TITLE
fix(lp): App Clipの宣言をapple-itunes-appメタタグに復活

### DIFF
--- a/apps/lp/src/pages/index.astro
+++ b/apps/lp/src/pages/index.astro
@@ -73,7 +73,7 @@ const lcpImageSources = lcpFormats.map((format, index) => {
     <meta name="twitter:app:name:googleplay" content="TrainLCD" />
     <meta name="twitter:app:id:googleplay" content="me.tinykitten.trainlcd" />
     <meta property="fb:app_id" content="596269604527027" />
-    <meta name="apple-itunes-app" content="app-id=1486355943" />
+    <meta name="apple-itunes-app" content="app-id=1486355943, app-clip-bundle-id=me.tinykitten.trainlcd.Clip, app-clip-display=card" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
     <link


### PR DESCRIPTION
## 概要

以前のコミットで削除された App Clip の宣言を `apple-itunes-app` メタタグに復活させました。

## 変更内容

`apps/lp/src/pages/index.astro`

```diff
-<meta name="apple-itunes-app" content="app-id=1486355943" />
+<meta name="apple-itunes-app" content="app-id=1486355943, app-clip-bundle-id=me.tinykitten.trainlcd.Clip, app-clip-display=card" />
```

## 背景

`b48978b` (Remove App Clip declaration from apple-itunes-app meta tag) で `app-clip-bundle-id` と `app-clip-display` が削除されていたため、当時の値をそのまま復元しています。

なお `apps/lp/public/.well-known/apple-app-site-association` の `appclips` セクション (`E6R2G33Z36.me.tinykitten.trainlcd.Clip` / `.dev.Clip`) は削除されておらず現存しているため、そちらは変更していません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYuL8r6NxPDF3DnFBYxDCT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * App Clip のバンドルIDと表示形式を、iTunes向けメタデータに追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->